### PR TITLE
Incomplete command handling

### DIFF
--- a/src/Servus.Akka.Telegram.TestBot/MongoConfiguration.cs
+++ b/src/Servus.Akka.Telegram.TestBot/MongoConfiguration.cs
@@ -1,0 +1,15 @@
+namespace Servus.Akka.Telegram.TestBot;
+
+public class MongoConfiguration
+{
+    public static readonly string Configuration = "MongoConfiguration";
+
+    public string Host { get; set; } = "";
+    public int Port { get; set; } = 27017;
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+    public string Database { get; set; } = "";
+
+    public string GetConnectionString()
+        => $"mongodb+srv://{Username}:{Password}@{Host}/{Database}";
+}

--- a/src/Servus.Akka.Telegram.TestBot/Repos/InviteRepository.cs
+++ b/src/Servus.Akka.Telegram.TestBot/Repos/InviteRepository.cs
@@ -1,6 +1,6 @@
 using LanguageExt;
 using MongoDB.Driver;
-using Servus.Akka.Telegram.Services;
+using Servus.Akka.Telegram.Services.Invites;
 
 namespace Servus.Akka.Telegram.TestBot.Repos;
 

--- a/src/Servus.Akka.Telegram.TestBot/Worker/HelloCommandWorker.cs
+++ b/src/Servus.Akka.Telegram.TestBot/Worker/HelloCommandWorker.cs
@@ -2,9 +2,9 @@ using Akka.Hosting;
 using Microsoft.Extensions.Logging;
 using Servus.Akka.Telegram.Users;
 
-namespace Servus.Akka.Telegram.TestBot.CommandWorker;
+namespace Servus.Akka.Telegram.TestBot.Worker;
 
-public class HelloCommandWorker : Telegram.CommandWorker
+public class HelloCommandWorker : CommandWorker
 {
     public HelloCommandWorker(BotUser user, ActorRegistry registry, ILogger<StartStopCommandWorker> logger) : base(user, registry, logger)
     {

--- a/src/Servus.Akka.Telegram.TestBot/Worker/InviteCreationWorker.cs
+++ b/src/Servus.Akka.Telegram.TestBot/Worker/InviteCreationWorker.cs
@@ -2,13 +2,13 @@ using Akka.Actor;
 using Akka.Hosting;
 using Microsoft.Extensions.Logging;
 using Servus.Akka.Telegram.Messages;
-using Servus.Akka.Telegram.Services;
+using Servus.Akka.Telegram.Services.Invites;
 using Servus.Akka.Telegram.TestBot.Repos;
 using Servus.Akka.Telegram.Users;
 
 namespace Servus.Akka.Telegram.TestBot.Worker;
 
-public class InviteCreationWorker : Telegram.CommandWorker
+public class InviteCreationWorker : CommandWorker
 {
     private readonly TestInviteExtensionRepository _repository;
     private readonly IActorRef _invitationController;

--- a/src/Servus.Akka.Telegram.TestBot/Worker/InviteCreationWorker.cs
+++ b/src/Servus.Akka.Telegram.TestBot/Worker/InviteCreationWorker.cs
@@ -31,6 +31,11 @@ public class InviteCreationWorker : CommandWorker
         });
         
         RegisterCommand("/test", ProcessCommand);
+        
+        RegisterIncompleteCommand("/test", (list, _) =>
+        {
+            ReplyText($"It is one parameter required to execute your command! You supplied: {list.Count}]");
+        });
     }
 
     private void ProcessCommand(IList<string> args, ChatInformation chatInfo)

--- a/src/Servus.Akka.Telegram.TestBot/Worker/StartCommandWorker.cs
+++ b/src/Servus.Akka.Telegram.TestBot/Worker/StartCommandWorker.cs
@@ -3,9 +3,9 @@ using Microsoft.Extensions.Logging;
 using Servus.Akka.Telegram.Messages;
 using Servus.Akka.Telegram.Users;
 
-namespace Servus.Akka.Telegram.TestBot.CommandWorker;
+namespace Servus.Akka.Telegram.TestBot.Worker;
 
-public class StartCommandWorker : Telegram.CommandWorker
+public class StartCommandWorker : CommandWorker
 {
     public StartCommandWorker(BotUser user, ActorRegistry registry, ILogger<StartCommandWorker> logger) : base(user, registry, logger)
     {

--- a/src/Servus.Akka.Telegram.TestBot/Worker/StartStopCommandWorker.cs
+++ b/src/Servus.Akka.Telegram.TestBot/Worker/StartStopCommandWorker.cs
@@ -1,10 +1,8 @@
-using Akka.Dispatch.SysMsg;
 using Akka.Hosting;
 using Microsoft.Extensions.Logging;
-using Servus.Akka.Telegram.Messages;
 using Servus.Akka.Telegram.Users;
 
-namespace Servus.Akka.Telegram.TestBot.CommandWorker;
+namespace Servus.Akka.Telegram.TestBot.Worker;
 
 public class StartStopCommandWorker : PersistentCommandWorker
 {
@@ -34,7 +32,7 @@ public class StartStopCommandWorker : PersistentCommandWorker
             {
                 _logger.LogDebug("Started at {CurrentTime}", start.Time);
                 _startTime = start.Time;
-                ReplyText("Your time running...");
+                ReplyText("Your time is running...");
             });
         });
         

--- a/src/Servus.Akka.Telegram/Hosting/AkkaHostingExtensions.cs
+++ b/src/Servus.Akka.Telegram/Hosting/AkkaHostingExtensions.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using Akka.Actor;
 using Akka.Cluster.Hosting;
 using Akka.DependencyInjection;
@@ -7,6 +6,7 @@ using Akka.Remote.Hosting;
 using Servus.Akka.Telegram.Messages;
 using Servus.Akka.Telegram.Registry;
 using Servus.Akka.Telegram.Services;
+using Servus.Akka.Telegram.Services.Invites;
 using Servus.Akka.Telegram.Users;
 
 namespace Servus.Akka.Telegram.Hosting;

--- a/src/Servus.Akka.Telegram/Hosting/WorkerRegistryExtension.cs
+++ b/src/Servus.Akka.Telegram/Hosting/WorkerRegistryExtension.cs
@@ -1,5 +1,4 @@
 using Akka.Actor;
-using Akka.Hosting;
 using Servus.Akka.Telegram.Registry;
 
 namespace Servus.Akka.Telegram.Hosting;

--- a/src/Servus.Akka.Telegram/Messages/CommandMessage.cs
+++ b/src/Servus.Akka.Telegram/Messages/CommandMessage.cs
@@ -1,3 +1,8 @@
 namespace Servus.Akka.Telegram.Messages;
 
-internal record CommandMessage(string Command, ChatInformation ChatInformation, IList<string> Arguments);
+internal abstract record CommandMessageBase(string Command, ChatInformation ChatInformation);
+internal record CommandMessage(string Command, ChatInformation ChatInformation, IList<string> Arguments)
+    : CommandMessageBase(Command, ChatInformation);
+
+internal record IncompleteCommandMessage(string Command, ChatInformation ChatInformation, IList<string> Arguments)
+    : CommandMessageBase(Command, ChatInformation);

--- a/src/Servus.Akka.Telegram/Messages/CreateNewInvitation.cs
+++ b/src/Servus.Akka.Telegram/Messages/CreateNewInvitation.cs
@@ -1,4 +1,4 @@
-using Servus.Akka.Telegram.Services;
+using Servus.Akka.Telegram.Services.Invites;
 using Servus.Akka.Telegram.Users;
 
 namespace Servus.Akka.Telegram.Messages;

--- a/src/Servus.Akka.Telegram/Messages/TelegramCommand.cs
+++ b/src/Servus.Akka.Telegram/Messages/TelegramCommand.cs
@@ -1,4 +1,4 @@
 namespace Servus.Akka.Telegram.Messages;
 
-public record TelegramCommand(long UserId, long MessageId, string Message, string Command, IList<string> Parameters, ChatInformation ChatInformation) : TelegramMessageBase(UserId, MessageId, Message, ChatInformation);
+public record TelegramCommand(long UserId, long MessageId, string Message, string Command, string[] Parameters, ChatInformation ChatInformation) : TelegramMessageBase(UserId, MessageId, Message, ChatInformation);
 public record TelegramText(long UserId, long MessageId, string Message, ChatInformation ChatInformation) : TelegramMessageBase(UserId, MessageId, Message, ChatInformation);

--- a/src/Servus.Akka.Telegram/Registry/ExecutionRule.cs
+++ b/src/Servus.Akka.Telegram/Registry/ExecutionRule.cs
@@ -37,13 +37,14 @@ internal class ExecutionRule
                     command.Parameters.Join(" ")
                 }
             };
-        
-        return RoleMatches(user)
-               && command.Command == _commandName
-               && command.Parameters.Length == _paramCount;
+
+        return RoleMatches(user) && CommandMatches(command);
     }
 
-    private bool RoleMatches(BotUser user)
+    internal  bool CommandMatches(TelegramCommand command) => command.Command == _commandName;
+    internal bool AllParametersSupplied(TelegramCommand command) => command.Parameters.Length == _paramCount;
+
+    internal bool RoleMatches(BotUser user)
     {
         if (_requiredRole == string.Empty && _additionRole == string.Empty)
             return true;
@@ -53,7 +54,7 @@ internal class ExecutionRule
         {
             result &= user.Roles.Contains(_additionRole);
         }
-        
+
         return result || user.Roles.Contains("admin");
     }
 }

--- a/src/Servus.Akka.Telegram/Registry/ExecutionRule.cs
+++ b/src/Servus.Akka.Telegram/Registry/ExecutionRule.cs
@@ -40,7 +40,7 @@ internal class ExecutionRule
         
         return RoleMatches(user)
                && command.Command == _commandName
-               && command.Parameters.Count == _paramCount;
+               && command.Parameters.Length == _paramCount;
     }
 
     private bool RoleMatches(BotUser user)

--- a/src/Servus.Akka.Telegram/Registry/WorkerRegistry.cs
+++ b/src/Servus.Akka.Telegram/Registry/WorkerRegistry.cs
@@ -1,4 +1,6 @@
+using System.ComponentModel.Design;
 using Akka.Actor;
+using LanguageExt;
 using Servus.Akka.Telegram.Hosting;
 using Servus.Akka.Telegram.Messages;
 using Servus.Akka.Telegram.Users;
@@ -12,13 +14,21 @@ public class WorkerRegistry : IExtension
     internal void Register(WorkerRegistration registration)
         => _registrations.Add(registration);
 
-    internal bool CheckAndExecute(TelegramCommand msg, BotUser user, Action<Func<BotUser, Props>, string> action)
+    internal bool CheckAndExecute(TelegramCommand msg, BotUser user,
+        Action<Func<BotUser, Props>, string, CommandMessageBase> action)
     {
         var executed = false;
         foreach (var workerRegistration in _registrations.Where(r => r.CanExecute(msg, user)))
         {
-            action(workerRegistration.PropsFactory, workerRegistration.Id);
-            executed = true;
+            workerRegistration.GetExecutionRule(msg, user).Some(rule =>
+            {
+                CommandMessageBase message = rule.AllParametersSupplied(msg)
+                    ? new CommandMessage(msg.Command, msg.ChatInformation, msg.Parameters)
+                    : new IncompleteCommandMessage(msg.Command, msg.ChatInformation, msg.Parameters);
+                
+                action(workerRegistration.PropsFactory, workerRegistration.Id, message);
+                executed = true;
+            }).None(() => { });
         }
 
         return executed;
@@ -34,8 +44,8 @@ internal class WorkerRegistration
 {
     internal string Id { get; } = Guid.NewGuid().ToString();
     internal Func<BotUser, Props> PropsFactory { get; }
-    
-    private readonly string _requiredRole;    
+
+    private readonly string _requiredRole;
     private readonly ExecutionRule[] _executionRules;
 
     internal WorkerRegistration(string requiredRole, Func<BotUser, Props> propsFactory, ExecutionRule[] executionRules)
@@ -45,8 +55,9 @@ internal class WorkerRegistration
         _executionRules = executionRules;
     }
 
-    internal bool CanExecute(TelegramCommand command, BotUser user)
-        => _executionRules.Any(r => r.CanExecute(command, user));
-    
-    
+    internal bool CanExecute(TelegramCommand command, BotUser user) =>
+        _executionRules.Any(r => r.CanExecute(command, user));
+
+    internal Option<ExecutionRule> GetExecutionRule(TelegramCommand command, BotUser user)
+        => _executionRules.FirstOrDefault(r => r.CommandMatches(command) && r.RoleMatches(user));
 }

--- a/src/Servus.Akka.Telegram/Services/Invites/IInviteRepository.cs
+++ b/src/Servus.Akka.Telegram/Services/Invites/IInviteRepository.cs
@@ -1,6 +1,6 @@
 using LanguageExt;
 
-namespace Servus.Akka.Telegram.Services;
+namespace Servus.Akka.Telegram.Services.Invites;
 
 public interface IInviteRepository
 {

--- a/src/Servus.Akka.Telegram/Services/Invites/Invitation.cs
+++ b/src/Servus.Akka.Telegram/Services/Invites/Invitation.cs
@@ -1,3 +1,3 @@
-namespace Servus.Akka.Telegram.Services;
+namespace Servus.Akka.Telegram.Services.Invites;
 
 public record Invitation(string Code, DateTime ValidUntil, string Role, string ActorName, string FirstName, string LastName, string[] UserRoles);

--- a/src/Servus.Akka.Telegram/Services/Invites/InvitationController.cs
+++ b/src/Servus.Akka.Telegram/Services/Invites/InvitationController.cs
@@ -1,11 +1,10 @@
 using Akka.Actor;
-using Akka.Cluster.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Servus.Akka.Telegram.Hosting;
 using Servus.Akka.Telegram.Hosting.Configuration;
 using Servus.Akka.Telegram.Messages;
 
-namespace Servus.Akka.Telegram.Services;
+namespace Servus.Akka.Telegram.Services.Invites;
 
 public class InvitationController : ReceiveActor
 {

--- a/src/Servus.Akka.Telegram/Services/Invites/InviteCodeGenerator.cs
+++ b/src/Servus.Akka.Telegram/Services/Invites/InviteCodeGenerator.cs
@@ -1,4 +1,4 @@
-namespace Servus.Akka.Telegram.Services;
+namespace Servus.Akka.Telegram.Services.Invites;
 
 internal static class InviteCodeGenerator
 {

--- a/src/Servus.Akka.Telegram/Services/UserShardRegion.cs
+++ b/src/Servus.Akka.Telegram/Services/UserShardRegion.cs
@@ -1,12 +1,10 @@
 using Akka.Actor;
 using Akka.Hosting;
-using Akka.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Servus.Akka.Telegram.Messages;
 using Servus.Akka.Telegram.Registry;
 using Servus.Akka.Telegram.Users;
-using Telegram.Bot.Types;
 
 namespace Servus.Akka.Telegram.Services;
 
@@ -64,7 +62,7 @@ public class UserShardRegion : ReceiveActor
                 if (worker.IsNobody())
                 {
                     var prop = propFac(_user);
-                    _logger.LogDebug("Creating new worker [{WorkerType}] for command [{TelegramCommand}] with [{ArgumentCount}] arguments", prop.TypeName, msg.Command, msg.Parameters.Count);
+                    _logger.LogDebug("Creating new worker [{WorkerType}] for command [{TelegramCommand}] with [{ArgumentCount}] arguments", prop.TypeName, msg.Command, msg.Parameters.Length);
                     worker = Context.ActorOf(prop, workerId);
                 }
                 

--- a/src/Servus.Akka.Telegram/TelegramIngress.cs
+++ b/src/Servus.Akka.Telegram/TelegramIngress.cs
@@ -1,17 +1,15 @@
 ﻿using Akka.Actor;
 using Akka.Cluster.Routing;
-using Akka.Configuration;
 using Akka.Hosting;
 using Akka.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualBasic;
 using Servus.Akka.Telegram.Hosting;
 using Servus.Akka.Telegram.Hosting.Configuration;
 using Servus.Akka.Telegram.Messages;
 using Servus.Akka.Telegram.Services;
+using Servus.Akka.Telegram.Services.Invites;
 using Servus.Akka.Telegram.Users;
-using Telegram.Bot.Requests.Abstractions;
 
 namespace Servus.Akka.Telegram;
 
@@ -39,7 +37,7 @@ public class TelegramIngress : ReceiveActor
 
         Receive<TelegramCommand>(msg =>
         {
-            if (msg.Command == "/start" && msg.Parameters.Count == 1)
+            if (msg.Command == "/start" && msg.Parameters.Length == 1)
             {
                 // user invite!
                 logger.LogDebug("Processing new invite....");


### PR DESCRIPTION
It is now possible to also handle a command when it does not match the parameter count required from the CommandWorker registration. This also fixes a bug when a parameter is an email address.